### PR TITLE
Widening the Pool Information Card

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.component.html
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.html
@@ -217,7 +217,7 @@
     <!-- Pool Information Row -->
     <div class="row mt-4 d-flex align-items-stretch">
       <!-- Pool Information Card -->
-      <div class="col-12 col-lg-6">
+      <div class="col-12 col-xl-6">
         <!-- Connected? -->
         <ng-container *ngIf="info.isStratumConnected; else disconnected">
           <nb-card class="h-100">


### PR DESCRIPTION
Makes the pool information card at home full width. The card is halved in width from the XL breakpoint.

Fix bug #150